### PR TITLE
Fix error messages

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.pingidentity</groupId>
     <artifactId>sync-group-dereference</artifactId>
-    <version>0.3.4.1</version>
+    <version>0.3.4.2</version>
     <packaging>jar</packaging>
     <name>sync-group-dereference</name>
     <description>A set of extensions aimed at tackling group sync use cases</description>

--- a/src/main/java/com/pingidentity/sync/pipe/TouchDereferenceOperation.java
+++ b/src/main/java/com/pingidentity/sync/pipe/TouchDereferenceOperation.java
@@ -59,7 +59,7 @@ public class TouchDereferenceOperation implements DereferenceOperation
             connection.modify(modifyRequest);
         } catch (LDAPException e)
         {
-            context.logMessage(LogSeverity.DEBUG, e.getDiagnosticMessage());
+            context.logMessage(LogSeverity.MILD_ERROR, e.getMessage());
         }
     }
 }

--- a/src/main/java/com/pingidentity/sync/pipe/WholeEntryDereferenceOperation.java
+++ b/src/main/java/com/pingidentity/sync/pipe/WholeEntryDereferenceOperation.java
@@ -80,7 +80,7 @@ public class WholeEntryDereferenceOperation implements DereferenceOperation
             queue.add(changeRecord);
         } catch (LDAPException e)
         {
-            context.logMessage(LogSeverity.FATAL_ERROR, e.getDiagnosticMessage());
+            context.logMessage(LogSeverity.MILD_ERROR, e.getMessage());
         }
     }
 }


### PR DESCRIPTION
We found the root cause of our issue which we couldn't see prior to this due to an error where the log message would not log since diagnosticMessage was null.  The change to use the synchronized block for the queue seems to have fixed the problem for us however we had another problem in the stage environment which this PR will expose.

Thanks again for the assist. 