### PR TITLE
prevent tight loop/cpu starvation

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.pingidentity</groupId>
     <artifactId>sync-group-dereference</artifactId>
-    <version>0.3.4.2</version>
+    <version>0.3.4.3</version>
     <packaging>jar</packaging>
     <name>sync-group-dereference</name>
     <description>A set of extensions aimed at tackling group sync use cases</description>

--- a/src/main/java/com/pingidentity/sync/pipe/GroupDereference.java
+++ b/src/main/java/com/pingidentity/sync/pipe/GroupDereference.java
@@ -140,6 +140,8 @@ public class GroupDereference extends SyncPipePlugin
         if (value != null)
         {
             rateBarrier = new FixedRateBarrier(1000L, value);
+        } else {
+            rateBarrier = new FixedRateBarrier(1000L, 1000);
         }
         
         abortSync = parser.getBooleanArgument(ARG_NAME_ABORT_SYNC).isPresent();


### PR DESCRIPTION
I noticed when adding threads that each added thread consumed an entire CPU core (or vCPU).  This occurs because there is no default rate limiting so the thread takes as much CPU as it is able to consume.  Not sure the default I chose is right but making this change caused us to go from 100% CPU on an r5.large to 27% on average, most of which is just ping sync itself I think.

Do you think this is a sane default?  1000 operations in 1000 ms?