### PR TITLE
WIP - Override touch server

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -250,6 +250,12 @@
             <version>${server-sdk.maven-version}</version>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>com.unboundid</groupId>
+            <artifactId>unboundid-ldapsdk</artifactId>
+            <version>4.0.11</version>
+            <scope>provided</scope>
+        </dependency>
     </dependencies>
     <profiles>
         <profile>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.pingidentity</groupId>
     <artifactId>sync-group-dereference</artifactId>
-    <version>0.3.4.4</version>
+    <version>0.3.5.0</version>
     <packaging>jar</packaging>
     <name>sync-group-dereference</name>
     <description>A set of extensions aimed at tackling group sync use cases</description>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.pingidentity</groupId>
     <artifactId>sync-group-dereference</artifactId>
-    <version>0.3.4.3</version>
+    <version>0.3.4.4</version>
     <packaging>jar</packaging>
     <name>sync-group-dereference</name>
     <description>A set of extensions aimed at tackling group sync use cases</description>

--- a/src/main/java/com/pingidentity/sync/pipe/GroupDereference.java
+++ b/src/main/java/com/pingidentity/sync/pipe/GroupDereference.java
@@ -52,9 +52,9 @@ public class GroupDereference extends SyncPipePlugin
     private String parseMode;
     private boolean abortSync;
 
-    AtomicLong maxQueueSize = new AtomicLong(0L);
-    AtomicLong queueAddFailures = new AtomicLong(0L);
-    AtomicLong queueAddAttempts = new AtomicLong(0L);
+    static AtomicLong maxQueueSize = new AtomicLong(0L);
+    static AtomicLong queueAddFailures = new AtomicLong(0L);
+    static AtomicLong queueAddAttempts = new AtomicLong(0L);
     
     
     /**

--- a/src/main/java/com/pingidentity/sync/pipe/GroupDereferenceMonitorProvider.java
+++ b/src/main/java/com/pingidentity/sync/pipe/GroupDereferenceMonitorProvider.java
@@ -1,15 +1,28 @@
 package com.pingidentity.sync.pipe;
 
 import com.unboundid.directory.sdk.common.api.MonitorProvider;
+import com.unboundid.directory.sdk.common.config.MonitorProviderConfig;
+import com.unboundid.directory.sdk.common.types.ServerContext;
 import com.unboundid.ldap.sdk.Attribute;
+import com.unboundid.ldap.sdk.LDAPException;
+import com.unboundid.ldap.sdk.ResultCode;
+import com.unboundid.util.args.ArgumentParser;
 import org.w3c.dom.Attr;
 
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
 import java.util.ArrayList;
+import java.util.Calendar;
 import java.util.List;
+import java.util.Queue;
 
 public class GroupDereferenceMonitorProvider extends MonitorProvider {
 
     private GroupDereference groupDereference;
+    DateFormat dateFormat = new SimpleDateFormat("MM/dd/yyyy hh:mm:ss");
+
+    private volatile MonitorProviderConfig config;
+    private ServerContext serverContext;
 
     /**
      * An empty constructor is *required*
@@ -21,29 +34,64 @@ public class GroupDereferenceMonitorProvider extends MonitorProvider {
         this.groupDereference = groupDereference;
     }
 
-
     @Override
     public String getExtensionName() {
-        return "GroupDereferenceOperationQueueMonitorProvider";
+        return "GroupDereferenceMonitorProvider";
     }
 
     @Override
     public String[] getExtensionDescription() {
-        return new String[]{"This monitor provider tracks metrics for the GroupDereferenceOperationQueue"};
+        return new String[]{"This monitor provider tracks metrics for GroupDereference"};
     }
 
     @Override
     public String getMonitorInstanceName() {
-        return null;
+        return "Group Dereference Monitor Provider " + config.getConfigObjectName();
+    }
+
+    @Override()
+    public void initializeMonitorProvider(final ServerContext serverContext,
+                                          final MonitorProviderConfig config,
+                                          final ArgumentParser parser)
+            throws LDAPException {
+        this.serverContext = serverContext;
+        this.config = config;
+    }
+
+    @Override()
+    public boolean isConfigurationAcceptable(final MonitorProviderConfig config,
+                                             final ArgumentParser parser,
+                                             final List<String> unacceptableReasons) {
+        return true;
+    }
+
+    @Override()
+    public long getUpdateIntervalMillis() {
+        return 10000L;
+    }
+
+    @Override()
+    public ResultCode applyConfiguration(final MonitorProviderConfig config,
+                                         final ArgumentParser parser,
+                                         final List<String> adminActionsRequired,
+                                         final List<String> messages) {
+        this.config = config;
+        return ResultCode.SUCCESS;
     }
 
     @Override
     public List<Attribute> getMonitorAttributes() {
-        List<Attribute> result = new ArrayList<>(1);
-        result.add(new Attribute("current-queue-size",Integer.toString(groupDereference.queue.size())));
-        result.add(new Attribute("max-queue-size",Long.toString(groupDereference.maxQueueSize.get())));
-        result.add(new Attribute("queue-add-attempts",Long.toString(groupDereference.queueAddAttempts.get())));
-        result.add(new Attribute("queue-add-failures",Long.toString(groupDereference.queueAddFailures.get())));
+        List<Attribute> result = new ArrayList<>();
+
+        result.add(new Attribute("monitor-last-updated",dateFormat.format(Calendar.getInstance().getTime())));
+
+        Queue<DereferenceOperation> queue = DereferenceOperationQueue.getInstance();
+
+        result.add(new Attribute("current-queue-size",Integer.toString(queue.size())));
+        result.add(new Attribute("max-queue-size",Long.toString(GroupDereference.maxQueueSize.get())));
+        result.add(new Attribute("queue-add-attempts",Long.toString(GroupDereference.queueAddAttempts.get())));
+        result.add(new Attribute("queue-add-failures",Long.toString(GroupDereference.queueAddFailures.get())));
+
         return result;
     }
 }

--- a/src/main/java/com/pingidentity/sync/pipe/GroupDereferenceMonitorProvider.java
+++ b/src/main/java/com/pingidentity/sync/pipe/GroupDereferenceMonitorProvider.java
@@ -18,7 +18,6 @@ import java.util.Queue;
 
 public class GroupDereferenceMonitorProvider extends MonitorProvider {
 
-    private GroupDereference groupDereference;
     DateFormat dateFormat = new SimpleDateFormat("MM/dd/yyyy hh:mm:ss");
 
     private volatile MonitorProviderConfig config;
@@ -28,10 +27,6 @@ public class GroupDereferenceMonitorProvider extends MonitorProvider {
      * An empty constructor is *required*
      */
     public GroupDereferenceMonitorProvider() {
-    }
-
-    public GroupDereferenceMonitorProvider(GroupDereference groupDereference){
-        this.groupDereference = groupDereference;
     }
 
     @Override
@@ -87,10 +82,27 @@ public class GroupDereferenceMonitorProvider extends MonitorProvider {
 
         Queue<DereferenceOperation> queue = DereferenceOperationQueue.getInstance();
 
-        result.add(new Attribute("current-queue-size",Integer.toString(queue.size())));
-        result.add(new Attribute("max-queue-size",Long.toString(GroupDereference.maxQueueSize.get())));
-        result.add(new Attribute("queue-add-attempts",Long.toString(GroupDereference.queueAddAttempts.get())));
-        result.add(new Attribute("queue-add-failures",Long.toString(GroupDereference.queueAddFailures.get())));
+        result.add(new Attribute("current-queue-size", Integer.toString(queue.size())));
+        result.add(new Attribute("max-queue-size", Long.toString(GroupDereference.maxQueueSize.get())));
+        result.add(new Attribute("queue-add-attempts", Long.toString(GroupDereference.queueAddAttempts.get())));
+        result.add(new Attribute("queue-add-failures", Long.toString(GroupDereference.queueAddFailures.get())));
+
+        if (GroupDereference.touchMemberDestOverrideConnectionPool != null) {
+            result.add(new Attribute("dest-override-pool-max-conns",
+                    Integer.toString(GroupDereference.touchMemberDestOverrideConnectionPool.getConnectionPoolStatistics().getMaximumAvailableConnections())));
+            result.add(new Attribute("dest-override-pool-avail-conns",
+                    Integer.toString(GroupDereference.touchMemberDestOverrideConnectionPool.getConnectionPoolStatistics().getNumAvailableConnections())));
+            result.add(new Attribute("dest-override-pool-closed-defunct-conns",
+                    Long.toString(GroupDereference.touchMemberDestOverrideConnectionPool.getConnectionPoolStatistics().getNumConnectionsClosedDefunct())));
+            result.add(new Attribute("dest-override-pool-closed-expired-conns",
+                    Long.toString(GroupDereference.touchMemberDestOverrideConnectionPool.getConnectionPoolStatistics().getNumConnectionsClosedExpired())));
+            result.add(new Attribute("dest-override-pool-failed-checkouts",
+                    Long.toString(GroupDereference.touchMemberDestOverrideConnectionPool.getConnectionPoolStatistics().getNumFailedCheckouts())));
+            result.add(new Attribute("dest-override-pool-failed-conn-attempts",
+                    Long.toString(GroupDereference.touchMemberDestOverrideConnectionPool.getConnectionPoolStatistics().getNumFailedConnectionAttempts())));
+            result.add(new Attribute("dest-override-pool-success-checkouts",
+                    Long.toString(GroupDereference.touchMemberDestOverrideConnectionPool.getConnectionPoolStatistics().getNumSuccessfulCheckouts())));
+        }
 
         return result;
     }


### PR DESCRIPTION
This is more of a work in progress and I'm looking for feedback.  Goal is to fix #7 .

I tried a few things for this but was finding that it seemed like the best way to handle this is a separate connection pool.  It might be better to override a SyncDestination class for this but that was outside my understanding of the APIs.  Definitely would appreciate feedback.

At a high level, we want to be able to handle group changes in the same way for touch-member but don't want to write back to the source.  In our topology this is problematic because the server feeding PingSync is not a write master.  So we can have replication errors in TDS under heavier load.  

Also, updated the monitor for this change too.